### PR TITLE
fixes for source code linkage

### DIFF
--- a/Bundle/Resources/config/services.yml
+++ b/Bundle/Resources/config/services.yml
@@ -7,6 +7,7 @@ services:
         arguments:
             - '@twig'
             - '@oro_twig_inspector.file_link_formatter'
+            - '%kernel.project_dir%'
         public: true
 
     oro_twig_inspector.box_drawings:


### PR DESCRIPTION
This PR fixes the issues reported in #5.

The following description uses `http://localhost/public/_profiler/open?file=vendor/symfony/symfony/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig&line=11#line11` as example.

In detail this PR includes the following specific changes:

1. It ensures that the `file` argument is relative by removing the kernel's project directory from the file path given in `$file`. So instead of e.g. `file=/path/to/your/app/vendor/symfony/symfony/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig` only `file=vendor/symfony/symfony/src/Symfony/Bridge/Twig/Resources/views/Form/form_div_layout.html.twig` remains.

2. It adds a possible sub directory if the `public` folder is not equal to the web root which may happen in development environments. So instead of `http://localhost/_profiler/...` it properly uses `http://localhost/public/_profiler/` in these cases. This should not affect environments where no sub directory is used (for example production systems where the web root directly points to the `public/` folder) because `$request->getBasePath()` is empty then (see [description here](https://github.com/symfony/symfony/blob/master/src/Symfony/Component/HttpFoundation/Request.php#L854-L865)).

3. It uses `html_entity_decode` to convert `&amp;line=11` into `&line=11` because the `$url` is not used for output but for a redirect.
